### PR TITLE
fix: update symbols for loong64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ppp (2.4.9-1+1deepin1) unstable; urgency=medium
+
+  * update symbols for loong64
+
+ -- Chang Yang <yangchang@deepin.org>  Wed, 24 Jan 2024 11:52:22 +0800
+
 ppp (2.4.9-1+1) unstable; urgency=medium
 
   [ Samuel Thibault ]

--- a/debian/ppp.symbols
+++ b/debian/ppp.symbols
@@ -3,9 +3,9 @@ pppd.so.2.4.9 ppp #MINVER#
 # Ignore all symbols that start with an underscore in the Base module
  (regex|optional)"^_.*@Base$" 2.4.7-1+2~
 # Ignore $global$ which seems to appear on hppa only
- (optional)$global$@Base 2.4.7-1+2~
+ (optional|arch=!loong64)$global$@Base 2.4.7-1+2~
 # Ignore everything that claims it's part of glibc
- (regex|optional)"@GLIBC_" 2.4.7-1+2~
+ (regex|optional|arch=!loong64)"@GLIBC_" 2.4.7-1+2~
 # All others should be pppd symbols
  ChallengeHash@Base 2.4.7-1+2~
  ChapMS2@Base 2.4.7-1+2~
@@ -99,7 +99,7 @@ pppd.so.2.4.9 ppp #MINVER#
  crtscts@Base 2.4.7-1+2~
  cryptpap@Base 2.4.7-1+2~
  current_option@Base 2.4.7-1+2~
- data_start@Base 2.4.7-1+2~
+ (arch=!loong64)data_start@Base 2.4.7-1+2~
  db_key@Base 2.4.7-1+2~
  dbglog@Base 2.4.7-1+2~
  debug@Base 2.4.7-1+2~


### PR DESCRIPTION
imported from debian. fix loong64