### PR TITLE
feat: restore deepin patches on top of 2.5.2-1+1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+ppp (2.5.2-1+1deepin1) unstable; urgency=medium
+
+  * Restore deepin patches on top of 2.5.2-1+1.
+  * All previously present deepin patches are already included in the
+    upstream version or are not applicable to the new upstream release:
+    - CVE-2022-4603.patch: already fixed in upstream 2.5.2 source code
+      (pppdump/pppdump.c already has the bounds check)
+    - CVE-2024-58250.patch: already fixed in upstream 2.5.2 (passprompt
+      plugin removed, build system migrated to autotools)
+    - 010_scripts_README.diff: target file (scripts/README) removed upstream
+    - 011_scripts_redialer.diff: target file (scripts/redialer) removed upstream
+    - no_crypt_hack: crypt() calls already guarded by HAVE_CRYPT_H in upstream,
+      debian/rules handles udeb by stripping HAVE_CRYPT_H
+    - pppdump_use_zlib: targets Makefile.linux which does not exist in upstream
+      (autotools build system)
+    - replace-vendored-hash-functions.patch: upstream 2.5.2 already uses libcrypto
+      for hash functions via crypto.c/ppp-md5.c/ppp-md4.c/ppp-sha1.c
+
+ -- lichenggang <lichenggang@uniontech.com>  Fri, 17 Jul 2026 23:49:55 +0800
 ppp (2.5.2-1+1) unstable; urgency=medium
 
   * Upload to unstable.


### PR DESCRIPTION
## Summary

Restore deepin patches on top of version 2.5.2-1+1.

## Changes

After checking each previously present deepin patch against the upstream 2.5.2 release, all patches are either already included in the upstream source code or are not applicable to the new upstream release:

| Patch | Status | Reason |
|-------|--------|--------|
| CVE-2022-4603.patch | Already in upstream | pppdump/pppdump.c already has the bounds check |
| CVE-2024-58250.patch | Already in upstream | passprompt plugin removed, build system migrated to autotools |
| 010_scripts_README.diff | Not applicable | scripts/README file removed upstream |
| 011_scripts_redialer.diff | Not applicable | scripts/redialer file removed upstream |
| no_crypt_hack | Already handled | crypt() calls guarded by HAVE_CRYPT_H, debian/rules strips it for udeb |
| pppdump_use_zlib | Not applicable | targets Makefile.linux which no longer exists (autotools) |
| replace-vendored-hash-functions.patch | Already in upstream | upstream 2.5.2 uses libcrypto via crypto.c/ppp-md5.c/ppp-md4.c/ppp-sha1.c |

No actual patch files needed to be restored. Updated debian/changelog with version 2.5.2-1+1deepin1.